### PR TITLE
Add support for Chrome OS

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -14,4 +14,11 @@ jobs:
         with:
           api-level: 28
           emulator-options: ""
-          script: "./gradlew connectedCheck test detekt" 
+          script: "./gradlew connectedCheck test detekt"
+      
+      - name: upload failure
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: build-artifact
+          path: app/build

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -180,7 +180,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-oss-licenses:17.0.0")
     
     // Image loading
-    implementation("com.github.dhaval2404:imagepicker:1.5")
+    implementation("com.github.dhaval2404:imagepicker:1.6")
     implementation("com.github.florent37:inline-activity-result-kotlin:1.0.1")
     implementation("io.coil-kt:coil:0.8.0")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,4 +25,10 @@
         
     </application>
 
+    <!-- Some Chromebooks don't support touch. Although not essential,
+         it's a good idea to explicitly include this declaration. -->
+    <uses-feature android:name="android.hardware.touchscreen"
+        android:required="false" />
+
+
 </manifest>


### PR DESCRIPTION
This commit declares that using the touch screen is optional. This is believed to be what's necessary to add support to Chrome OS, however this stands untested.

This also updates the ImagePicker library, as that will turn the Camera permission optional. With the camera permission being optional, more chromebooks will be able to use the app, as they don't have cameras.

I couldn't execute the emulator in two different PCs, and I don't own a chromebook, so this will have to be field-tested.

Closes #39