### PR TITLE
test: migrate Robolectric suites from JUnit4 to Kotest specs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -262,11 +262,8 @@ dependencies {
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.compose.ui.test.junit4)
     testImplementation(libs.robolectric)
-    // Robolectric requires the JUnit4 runner (@RunWith(RobolectricTestRunner::class)); Kotest has no
-    // first-class Robolectric support (the community kotest-extensions-robolectric artifact pins
-    // kotest-framework-api 4.6.3 / robolectric 4.6.1, well behind this project's Kotest 5.9.1 /
-    // Robolectric 4.15.1, and was evaluated and rejected). junit-vintage-engine is what lets those
-    // JUnit4 specs keep running under the JUnit Platform alongside the Kotest suite.
-    testRuntimeOnly(libs.junit.vintage.engine)
+    // Kotest spec support for Robolectric (@RobolectricTest), see
+    // https://github.com/LeoColman/kotest-android
+    testImplementation(libs.kotest.extensions.android)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/ads/AdFreeStoreTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/ads/AdFreeStoreTest.kt
@@ -4,41 +4,34 @@ import android.app.Application
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.io.File
 import java.nio.file.Files
+
+private fun newStore(clock: () -> Long): AdFreeStore {
+    val dir = Files.createTempDirectory("adfree").toFile()
+    val dataStore: DataStore<Preferences> =
+        PreferenceDataStoreFactory.create { File(dir, "prefs.preferences_pb") }
+    return AdFreeStore(dataStore, clock = clock, tickMillis = 10L)
+}
 
 /**
  * Exercises the real DataStore + clock boundary of [AdFreeStore] under Robolectric. Each store gets a
  * fresh temp file so DataStore instances never clash, and a fake clock drives the week boundary.
  */
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
-class AdFreeStoreTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class AdFreeStoreTest : StringSpec({
 
-    private fun newStore(clock: () -> Long): AdFreeStore {
-        val dir = Files.createTempDirectory("adfree").toFile()
-        val dataStore: DataStore<Preferences> =
-            PreferenceDataStoreFactory.create { File(dir, "prefs.preferences_pb") }
-        return AdFreeStore(dataStore, clock = clock, tickMillis = 10L)
-    }
-
-    @Test
-    fun `defaults to ads enabled with no ad-free time`() = runBlocking {
+    "defaults to ads enabled with no ad-free time" {
         val store = newStore(clock = { 1_000L })
         store.adsEnabled.first() shouldBe true
         store.adFreeRemainingMillis.first() shouldBe 0L
-        Unit
     }
 
-    @Test
-    fun `granting a week hides ads and reports a full week remaining`() = runBlocking {
+    "granting a week hides ads and reports a full week remaining" {
         val now = 1_000_000L
         val store = newStore(clock = { now })
 
@@ -46,11 +39,9 @@ class AdFreeStoreTest {
 
         store.adsEnabled.first() shouldBe false
         store.adFreeRemainingMillis.first() shouldBe AdFreeStore.WEEK_MILLIS
-        Unit
     }
 
-    @Test
-    fun `ads return once the granted week has elapsed`() = runBlocking {
+    "ads return once the granted week has elapsed" {
         var now = 1_000_000L
         val store = newStore(clock = { now })
         store.grantAdFreeWeek()
@@ -60,6 +51,5 @@ class AdFreeStoreTest {
 
         store.adsEnabled.first() shouldBe true
         store.adFreeRemainingMillis.first() shouldBe 0L
-        Unit
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/ads/AdsModuleTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/ads/AdsModuleTest.kt
@@ -4,28 +4,23 @@ import android.app.Application
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import me.kerooker.rpgnpcgenerator.BuildConfig
-import org.junit.Test
-import org.junit.runner.RunWith
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.koinApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Verifies [adsModule] wiring in an isolated Koin container (mirrors ImageGenModuleTest). One test
  * method builds the graph once so only a single DataStore instance is created for the file.
  */
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
-class AdsModuleTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class AdsModuleTest : StringSpec({
 
-    private val context: Application = ApplicationProvider.getApplicationContext()
-
-    @Test
-    fun `adsModule resolves every dependency, feeds AdIds from BuildConfig, and shares singletons`() {
+    "adsModule resolves every dependency, feeds AdIds from BuildConfig, and shares singletons" {
+        val context: Application = ApplicationProvider.getApplicationContext()
         val koin = koinApplication {
             androidContext(context)
             modules(adsModule)
@@ -44,4 +39,4 @@ class AdsModuleTest {
             koin.close()
         }
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/analytics/AnalyticsModuleTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/analytics/AnalyticsModuleTest.kt
@@ -2,32 +2,29 @@ package me.kerooker.rpgnpcgenerator.analytics
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.types.shouldBeSameInstanceAs
-import org.junit.Test
-import org.junit.runner.RunWith
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.koinApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * Verifies [analyticsModule] wiring in an isolated Koin container (mirrors AdsModuleTest). Unit
  * tests run the debug variant, whose BuildConfig key is blank, so resolving never touches PostHog.
  */
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
-class AnalyticsModuleTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class AnalyticsModuleTest : StringSpec({
 
-    private val context: Application = ApplicationProvider.getApplicationContext()
+    lateinit var context: Application
 
-    @Test
-    fun `a blank api key disables analytics via the no-op implementation`() {
+    beforeTest { context = ApplicationProvider.getApplicationContext() }
+
+    "a blank api key disables analytics via the no-op implementation" {
         createAnalytics(context, "") shouldBeSameInstanceAs NoOpAnalytics
         createAnalytics(context, "   ") shouldBeSameInstanceAs NoOpAnalytics
     }
 
-    @Test
-    fun `analyticsModule resolves Analytics as a shared singleton`() {
+    "analyticsModule resolves Analytics as a shared singleton" {
         val koin = koinApplication {
             androidContext(context)
             modules(analyticsModule)
@@ -38,4 +35,4 @@ class AnalyticsModuleTest {
             koin.close()
         }
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/crash/CrashReportingTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/crash/CrashReportingTest.kt
@@ -2,29 +2,24 @@ package me.kerooker.rpgnpcgenerator.crash
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.sentry.Sentry
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * The blank-DSN gate is the whole privacy contract of [CrashReporting]: every debug build ships a
  * blank DSN, and a blank DSN must leave the SDK unstarted so nothing is ever sent from a dev device.
  */
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
-class CrashReportingTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class CrashReportingTest : StringSpec({
 
-    private val context: Application = ApplicationProvider.getApplicationContext()
+    lateinit var context: Application
 
-    @After
-    fun tearDown() = Sentry.close()
+    beforeTest { context = ApplicationProvider.getApplicationContext() }
+    afterTest { Sentry.close() }
 
-    @Test
-    fun `a blank dsn leaves crash reporting disabled`() {
+    "a blank dsn leaves crash reporting disabled" {
         CrashReporting.init(context, dsn = "")
         Sentry.isEnabled() shouldBe false
 
@@ -32,9 +27,8 @@ class CrashReportingTest {
         Sentry.isEnabled() shouldBe false
     }
 
-    @Test
-    fun `a real dsn enables crash reporting`() {
+    "a real dsn enables crash reporting" {
         CrashReporting.init(context, dsn = "https://public@glitchtip.example.com/1")
         Sentry.isEnabled() shouldBe true
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/data/RosterBackupServiceTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/data/RosterBackupServiceTest.kt
@@ -2,75 +2,67 @@ package me.kerooker.rpgnpcgenerator.data
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldEndWith
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.io.File
+
+private fun npc(
+    id: Long = 1,
+    fullName: String = "Aria Nightsong",
+    imagePath: String? = null
+) = Npc(
+    id = id,
+    fullName = fullName,
+    nickname = "The Swift",
+    gender = "Female",
+    sexuality = "Heterosexual",
+    race = "High Elf",
+    age = "Adult",
+    profession = "Ranger",
+    motivation = "Protect the forest",
+    alignment = "Neutral Good",
+    personalityTraits = listOf("Brave", "Curious"),
+    languages = listOf("Common", "Elvish"),
+    imagePath = imagePath,
+    notes = "Met in the tavern",
+    strength = null,
+    dexterity = null,
+    constitution = null,
+    intelligence = null,
+    wisdom = null,
+    charisma = null,
+    armorClass = null,
+    hitPoints = null,
+    challengeRating = null,
+    campaign = "Waterdeep",
+    items = emptyList()
+)
+
+private fun writePortraitFile(context: Application, bytes: ByteArray): String {
+    val directory = File(context.filesDir, "portraits").apply { mkdirs() }
+    val file = File(directory, "source-portrait.jpg")
+    file.writeBytes(bytes)
+    return file.absolutePath
+}
 
 /**
  * Exercises the real file + base64 paths of [RosterBackupService], so (like the other storage-touching
  * suites) it runs on Robolectric for a genuine `context.filesDir`.
  */
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
-class RosterBackupServiceTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class RosterBackupServiceTest : StringSpec({
 
-    private lateinit var context: Application
+    lateinit var context: Application
 
-    @Before
-    fun setUp() {
-        context = ApplicationProvider.getApplicationContext()
-    }
+    beforeTest { context = ApplicationProvider.getApplicationContext() }
 
-    private fun npc(
-        id: Long = 1,
-        fullName: String = "Aria Nightsong",
-        imagePath: String? = null
-    ) = Npc(
-        id = id,
-        fullName = fullName,
-        nickname = "The Swift",
-        gender = "Female",
-        sexuality = "Heterosexual",
-        race = "High Elf",
-        age = "Adult",
-        profession = "Ranger",
-        motivation = "Protect the forest",
-        alignment = "Neutral Good",
-        personalityTraits = listOf("Brave", "Curious"),
-        languages = listOf("Common", "Elvish"),
-        imagePath = imagePath,
-        notes = "Met in the tavern",
-        strength = null,
-        dexterity = null,
-        constitution = null,
-        intelligence = null,
-        wisdom = null,
-        charisma = null,
-        armorClass = null,
-        hitPoints = null,
-        challengeRating = null,
-        campaign = "Waterdeep",
-        items = emptyList()
-    )
-
-    private fun writePortraitFile(bytes: ByteArray): String {
-        val directory = File(context.filesDir, "portraits").apply { mkdirs() }
-        val file = File(directory, "source-portrait.jpg")
-        file.writeBytes(bytes)
-        return file.absolutePath
-    }
-
-    @Test
-    fun `export then import round-trips an npc with its portrait bytes into a new file`() {
+    "export then import round-trips an npc with its portrait bytes into a new file" {
         val portraitBytes = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
-        val sourcePath = writePortraitFile(portraitBytes)
+        val sourcePath = writePortraitFile(context, portraitBytes)
         val original = npc(id = 5, fullName = "Aria", imagePath = sourcePath)
 
         val json = RosterBackupService.exportJson(listOf(original))
@@ -87,15 +79,13 @@ class RosterBackupServiceTest {
         File(restored.imagePath!!).readBytes().toList() shouldBe portraitBytes.toList()
     }
 
-    @Test
-    fun `an npc without a portrait round-trips with a null image path`() {
+    "an npc without a portrait round-trips with a null image path" {
         val json = RosterBackupService.exportJson(listOf(npc(imagePath = null)))
 
         RosterBackupService.importNpcs(context, json).first().imagePath shouldBe null
     }
 
-    @Test
-    fun `export encodes every npc under a version and import restores them all`() {
+    "export encodes every npc under a version and import restores them all" {
         val json = RosterBackupService.exportJson(
             listOf(npc(fullName = "A", imagePath = null), npc(fullName = "B", imagePath = null))
         )
@@ -105,19 +95,17 @@ class RosterBackupServiceTest {
         imported.map { it.fullName } shouldBe listOf("A", "B")
     }
 
-    @Test
-    fun `importing a file that is not a backup throws`() {
+    "importing a file that is not a backup throws" {
         shouldThrow<Exception> {
             RosterBackupService.importNpcs(context, "this is not a backup file")
         }
     }
 
-    @Test
-    fun `a portrait whose file is missing exports as no portrait rather than failing`() {
+    "a portrait whose file is missing exports as no portrait rather than failing" {
         val original = npc(imagePath = "/nonexistent/portrait.jpg")
 
         val json = RosterBackupService.exportJson(listOf(original))
 
         RosterBackupService.importNpcs(context, json).first().imagePath shouldBe null
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/repository/image/GeneratePortraitWorkerTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/repository/image/GeneratePortraitWorkerTest.kt
@@ -8,12 +8,9 @@ import androidx.work.Configuration
 import androidx.work.WorkManager
 import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.concurrent.TimeUnit
 
 /**
@@ -25,14 +22,12 @@ import java.util.concurrent.TimeUnit
  * [GeneratePortraitWorker.doWork] is not exercised here: driving the CoroutineWorker end to end needs
  * work-testing's TestListenableWorkerBuilder plus a started Koin graph, out of scope for this test.
  */
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
-class GeneratePortraitWorkerTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class GeneratePortraitWorkerTest : StringSpec({
 
-    private lateinit var context: Context
+    lateinit var context: Context
 
-    @Before
-    fun setUp() {
+    beforeTest {
         context = ApplicationProvider.getApplicationContext()
         val config = Configuration.Builder()
             .setExecutor(SynchronousExecutor())
@@ -41,8 +36,7 @@ class GeneratePortraitWorkerTest {
         WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
     }
 
-    @Test
-    fun `enqueue schedules a unique work request for the npc`() {
+    "enqueue schedules a unique work request for the npc" {
         GeneratePortraitWorker.enqueue(context, 42L)
 
         // Exactly one work item under this npc's unique name. (We don't assert the run state: the
@@ -55,8 +49,7 @@ class GeneratePortraitWorkerTest {
         infos.size shouldBe 1
     }
 
-    @Test
-    fun `enqueue twice for the same npc keeps a single unique work item`() {
+    "enqueue twice for the same npc keeps a single unique work item" {
         GeneratePortraitWorker.enqueue(context, 7L)
         GeneratePortraitWorker.enqueue(context, 7L)
 
@@ -67,8 +60,7 @@ class GeneratePortraitWorkerTest {
         infos.size shouldBe 1
     }
 
-    @Test
-    fun `enqueue for different npc ids schedules independent work items`() {
+    "enqueue for different npc ids schedules independent work items" {
         GeneratePortraitWorker.enqueue(context, 1L)
         GeneratePortraitWorker.enqueue(context, 2L)
 
@@ -76,4 +68,4 @@ class GeneratePortraitWorkerTest {
         workManager.getWorkInfosForUniqueWork("portrait_1").get(10, TimeUnit.SECONDS).size shouldBe 1
         workManager.getWorkInfosForUniqueWork("portrait_2").get(10, TimeUnit.SECONDS).size shouldBe 1
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/repository/image/ImageGenModuleTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/repository/image/ImageGenModuleTest.kt
@@ -2,19 +2,15 @@ package me.kerooker.rpgnpcgenerator.repository.image
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import me.kerooker.rpgnpcgenerator.BuildConfig
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.KoinApplication
 import org.koin.dsl.koinApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 /**
  * koin-test isn't on this module's test classpath (no `org.koin.test.verify.verify()` available),
@@ -24,14 +20,12 @@ import org.robolectric.annotation.Config
  * Robolectric supplies the real Context that `androidContext(...)` and `PortraitNotifications`
  * both need.
  */
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
-class ImageGenModuleTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class ImageGenModuleTest : StringSpec({
 
-    private lateinit var koinApp: KoinApplication
+    lateinit var koinApp: KoinApplication
 
-    @Before
-    fun setUp() {
+    beforeTest {
         val context: Application = ApplicationProvider.getApplicationContext()
         koinApp = koinApplication {
             androidContext(context)
@@ -39,13 +33,9 @@ class ImageGenModuleTest {
         }
     }
 
-    @After
-    fun tearDown() {
-        koinApp.close()
-    }
+    afterTest { koinApp.close() }
 
-    @Test
-    fun `every definition declared by the module resolves`() {
+    "every definition declared by the module resolves" {
         val koin = koinApp.koin
 
         koin.get<RemoteImageConfig>().shouldBeInstanceOf<RemoteImageConfig>()
@@ -53,8 +43,7 @@ class ImageGenModuleTest {
         koin.get<PortraitNotifications>().shouldBeInstanceOf<PortraitNotifications>()
     }
 
-    @Test
-    fun `RemoteImageConfig is wired from BuildConfig fields`() {
+    "RemoteImageConfig is wired from BuildConfig fields" {
         val config = koinApp.koin.get<RemoteImageConfig>()
 
         config.baseUrl shouldBe BuildConfig.NPC_IMAGE_BASE_URL
@@ -62,11 +51,10 @@ class ImageGenModuleTest {
         config.password shouldBe BuildConfig.NPC_IMAGE_PASSWORD
     }
 
-    @Test
-    fun `RemoteImageConfig and PortraitQueueClient are shared singletons`() {
+    "RemoteImageConfig and PortraitQueueClient are shared singletons" {
         val koin = koinApp.koin
 
         koin.get<RemoteImageConfig>() shouldBeSameInstanceAs koin.get<RemoteImageConfig>()
         koin.get<PortraitQueueClient>() shouldBeSameInstanceAs koin.get<PortraitQueueClient>()
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/repository/image/PortraitNotificationsTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/repository/image/PortraitNotificationsTest.kt
@@ -5,16 +5,13 @@ import android.app.Notification
 import android.app.NotificationManager
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
-import org.robolectric.annotation.Config
 
 private const val CHANNEL_ID = "portrait_gen"
 
@@ -23,23 +20,20 @@ private const val CHANNEL_ID = "portrait_gen"
  * `NotificationManager`, so it's driven here via Robolectric (matching [PortraitQueueClient]'s test
  * in this same package).
  */
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
-class PortraitNotificationsTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class PortraitNotificationsTest : StringSpec({
 
-    private lateinit var context: Application
-    private lateinit var notificationManager: NotificationManager
-    private lateinit var notifications: PortraitNotifications
+    lateinit var context: Application
+    lateinit var notificationManager: NotificationManager
+    lateinit var notifications: PortraitNotifications
 
-    @Before
-    fun setUp() {
+    beforeTest {
         context = ApplicationProvider.getApplicationContext()
         notificationManager = context.getSystemService(NotificationManager::class.java)
         notifications = PortraitNotifications(context)
     }
 
-    @Test
-    fun `ensureChannel creates the portrait_gen channel`() {
+    "ensureChannel creates the portrait_gen channel" {
         notifications.ensureChannel()
 
         val channel = notificationManager.getNotificationChannel(CHANNEL_ID).shouldNotBeNull()
@@ -48,16 +42,14 @@ class PortraitNotificationsTest {
         channel.canShowBadge() shouldBe false
     }
 
-    @Test
-    fun `progress notification is ongoing with indeterminate progress`() {
+    "progress notification is ongoing with indeterminate progress" {
         val notification = notifications.progress("Aria Nightsong", "Queued")
 
         (notification.flags and Notification.FLAG_ONGOING_EVENT != 0) shouldBe true
         notification.extras.getBoolean(Notification.EXTRA_PROGRESS_INDETERMINATE) shouldBe true
     }
 
-    @Test
-    fun `notifyProgress posts a notification under the npc id`() {
+    "notifyProgress posts a notification under the npc id" {
         notifications.ensureChannel()
 
         notifications.notifyProgress(42L, "Aria Nightsong", "Queued")
@@ -65,8 +57,7 @@ class PortraitNotificationsTest {
         shadowOf(notificationManager).getNotification(42).shouldNotBeNull()
     }
 
-    @Test
-    fun `notifyReady posts an auto-cancel notification under the npc id`() {
+    "notifyReady posts an auto-cancel notification under the npc id" {
         notifications.ensureChannel()
 
         notifications.notifyReady(42L, "Aria Nightsong")
@@ -75,8 +66,7 @@ class PortraitNotificationsTest {
         (posted.flags and Notification.FLAG_AUTO_CANCEL != 0) shouldBe true
     }
 
-    @Test
-    fun `notifyFailed posts an auto-cancel notification under the npc id`() {
+    "notifyFailed posts an auto-cancel notification under the npc id" {
         notifications.ensureChannel()
 
         notifications.notifyFailed(99L, "Aria Nightsong")
@@ -85,8 +75,7 @@ class PortraitNotificationsTest {
         (posted.flags and Notification.FLAG_AUTO_CANCEL != 0) shouldBe true
     }
 
-    @Test
-    fun `safeNotify swallows failures instead of throwing`() {
+    "safeNotify swallows failures instead of throwing" {
         // A fully unstubbed Context makes every call inside safeNotify's runCatching block
         // (NotificationManagerCompat.from(context), building the notification, notify itself)
         // throw. The point of this test is that nothing escapes notifyProgress.
@@ -94,4 +83,4 @@ class PortraitNotificationsTest {
 
         shouldNotThrowAny { PortraitNotifications(throwingContext).notifyProgress(1L, "Name", "Text") }
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/repository/image/PortraitQueueClientTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/repository/image/PortraitQueueClientTest.kt
@@ -2,26 +2,22 @@ package me.kerooker.rpgnpcgenerator.repository.image
 
 import android.app.Application
 import android.util.Base64
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+
+private fun client(config: RemoteImageConfig = RemoteImageConfig("https://example.test", "user", "pass")) =
+    PortraitQueueClient(config)
 
 /**
  * [PortraitQueueClient.decode] goes through `android.util.Base64`, so it needs Robolectric to run
  * on the JVM. [submit]/[status] are not covered here: they open real sockets via
  * `HttpURLConnection`, which isn't worth faking for a unit test.
  */
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
-class PortraitQueueClientTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class PortraitQueueClientTest : StringSpec({
 
-    private fun client(config: RemoteImageConfig = RemoteImageConfig("https://example.test", "user", "pass")) =
-        PortraitQueueClient(config)
-
-    @Test
-    fun `decode decodes a plain base64 string`() {
+    "decode decodes a plain base64 string" {
         val expected = "hello world".toByteArray()
         val encoded = Base64.encodeToString(expected, Base64.NO_WRAP)
 
@@ -30,8 +26,7 @@ class PortraitQueueClientTest {
         decoded shouldBe expected
     }
 
-    @Test
-    fun `decode strips a data URI prefix before decoding`() {
+    "decode strips a data URI prefix before decoding" {
         val expected = "hello world".toByteArray()
         val encoded = Base64.encodeToString(expected, Base64.NO_WRAP)
         val prefixed = "data:image/png;base64,$encoded"
@@ -41,8 +36,7 @@ class PortraitQueueClientTest {
         decoded shouldBe expected
     }
 
-    @Test
-    fun `decode round-trips arbitrary bytes through encode and decode`() {
+    "decode round-trips arbitrary bytes through encode and decode" {
         val expected = byteArrayOf(0, 1, 2, 3, 127, -128, -1, 42, 100)
         val encoded = Base64.encodeToString(expected, Base64.NO_WRAP)
 
@@ -51,17 +45,15 @@ class PortraitQueueClientTest {
         decoded shouldBe expected
     }
 
-    @Test
-    fun `enabled is true when the injected config is enabled`() {
+    "enabled is true when the injected config is enabled" {
         val config = RemoteImageConfig(baseUrl = "https://example.test", username = "user", password = "pass")
 
         client(config).enabled shouldBe true
     }
 
-    @Test
-    fun `enabled is false when the injected config is disabled`() {
+    "enabled is false when the injected config is disabled" {
         val config = RemoteImageConfig(baseUrl = "", username = "user", password = "")
 
         client(config).enabled shouldBe false
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/repository/model/random/npc/NpcGeneratorsTests.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/repository/model/random/npc/NpcGeneratorsTests.kt
@@ -1,9 +1,8 @@
 package me.kerooker.rpgnpcgenerator.repository.model.random.npc
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.inspectors.forAll
-import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.ints.shouldBeInRange
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -30,8 +29,8 @@ private fun completeGenerator(): CompleteNpcGenerator {
 class CompleteNpcGeneratorTest : FunSpec() {
 
     private val target = completeGenerator()
-    private val childrenProfessions = rawLines("npc_child_professions.txt")
-    private val normalProfessions = rawLines("npc_professions.txt")
+    private val childrenProfessions = rawLines("npc_child_professions.txt").toSet()
+    private val normalProfessions = rawLines("npc_professions.txt").toSet()
 
     private fun generate(amount: Int) = List(amount) { target.generate() }
     private fun generateMany() = generate(100_000)
@@ -67,16 +66,18 @@ class CompleteNpcGeneratorTest : FunSpec() {
             } shouldBeInRange (4_700..5_300)
         }
 
+        // A single set-difference assertion rather than shouldContain per generated npc:
+        // shouldContain always copies its receiver via toList() and scans it fully to build a
+        // possible-failure message, even on success, so calling it per item (up to 100,000 times)
+        // against a ~400-line profession list made this test take minutes instead of seconds.
         test("Should generate a child profession if npc is child") {
-            generateMany().filter { it.age == Age.Child }.forAll {
-                childrenProfessions shouldContain it.profession
-            }
+            val generatedProfessions = generateMany().filter { it.age == Age.Child }.map { it.profession }.toSet()
+            generatedProfessions subtract childrenProfessions shouldBe emptySet()
         }
 
         test("Should generate a normal profession if npc is not a child") {
-            generateMany().filterNot { it.age == Age.Child }.forEach {
-                normalProfessions shouldContain it.profession
-            }
+            val generatedProfessions = generateMany().filterNot { it.age == Age.Child }.map { it.profession }.toSet()
+            generatedProfessions subtract normalProfessions shouldBe emptySet()
         }
 
         test("Should generate between 2 and 5 items, always starting with a coin pouch") {

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/components/NpcFieldTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/components/NpcFieldTest.kt
@@ -1,66 +1,62 @@
 package me.kerooker.rpgnpcgenerator.ui.components
 
 import android.app.Application
+import androidx.activity.ComponentActivity
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.runAndroidComposeUiTest
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import org.junit.Rule
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-import org.robolectric.annotation.GraphicsMode
 
-@RunWith(RobolectricTestRunner::class)
-@GraphicsMode(GraphicsMode.Mode.NATIVE)
-@Config(sdk = [34], application = Application::class)
-class NpcFieldTest {
+@OptIn(ExperimentalTestApi::class)
+@RobolectricTest(sdk = [34], application = Application::class)
+class NpcFieldTest : StringSpec({
 
-    @get:Rule
-    val composeRule = createComposeRule()
-
-    @Test
-    fun `displays the value and reroll invokes the callback`() {
+    "displays the value and reroll invokes the callback" {
         var rerolled = false
-        composeRule.setContent {
-            MaterialTheme {
-                NpcField(
-                    label = "Race",
-                    value = "Human",
-                    editable = true,
-                    onValueChange = {},
-                    onReroll = { rerolled = true }
-                )
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    NpcField(
+                        label = "Race",
+                        value = "Human",
+                        editable = true,
+                        onValueChange = {},
+                        onReroll = { rerolled = true }
+                    )
+                }
             }
-        }
 
-        composeRule.onNodeWithText("Human").assertIsDisplayed()
-        composeRule.onNodeWithContentDescription("Re-roll Race").performClick()
+            onNodeWithText("Human").assertIsDisplayed()
+            onNodeWithContentDescription("Re-roll Race").performClick()
+        }
 
         rerolled shouldBe true
     }
 
-    @Test
-    fun `editing the value propagates through onValueChange`() {
+    "editing the value propagates through onValueChange" {
         var current = "Human"
-        composeRule.setContent {
-            MaterialTheme {
-                NpcField(
-                    label = "Race",
-                    value = current,
-                    editable = true,
-                    onValueChange = { current = it }
-                )
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    NpcField(
+                        label = "Race",
+                        value = current,
+                        editable = true,
+                        onValueChange = { current = it }
+                    )
+                }
             }
-        }
 
-        composeRule.onNodeWithText("Human").performTextReplacement("Elf")
+            onNodeWithText("Human").performTextReplacement("Elf")
+        }
 
         current shouldBe "Elf"
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/share/NpcCardSharerTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/share/NpcCardSharerTest.kt
@@ -3,38 +3,28 @@ package me.kerooker.rpgnpcgenerator.ui.share
 import android.app.Application
 import android.graphics.Bitmap
 import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldEndWith
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-import org.robolectric.annotation.GraphicsMode
 import java.io.File
+
+private fun tinyBitmap(): Bitmap = Bitmap.createBitmap(8, 8, Bitmap.Config.ARGB_8888)
 
 /**
  * NpcCardSharer touches `context.cacheDir` and real `Bitmap.compress`, so (like ImageStoreTest) it
- * runs on Robolectric with GraphicsMode.NATIVE so PNG bytes are actually encoded.
+ * runs on Robolectric.
  */
-@RunWith(RobolectricTestRunner::class)
-@GraphicsMode(GraphicsMode.Mode.NATIVE)
-@Config(sdk = [34], application = Application::class)
-class NpcCardSharerTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class NpcCardSharerTest : StringSpec({
 
-    private lateinit var context: Application
+    lateinit var context: Application
 
-    @Before
-    fun setUp() {
-        context = ApplicationProvider.getApplicationContext()
-    }
+    beforeTest { context = ApplicationProvider.getApplicationContext() }
 
-    private fun tinyBitmap(): Bitmap = Bitmap.createBitmap(8, 8, Bitmap.Config.ARGB_8888)
-
-    @Test
-    fun `saveCardPng writes a png inside the shared_images cache directory`() {
+    "saveCardPng writes a png inside the shared_images cache directory" {
         val file = NpcCardSharer.saveCardPng(context, tinyBitmap())
 
         val sharedDir = File(context.cacheDir, "shared_images")
@@ -44,8 +34,7 @@ class NpcCardSharerTest {
         file.length() shouldBeGreaterThan 0
     }
 
-    @Test
-    fun `saveCardPng returns a distinct file on every call`() {
+    "saveCardPng returns a distinct file on every call" {
         val first = NpcCardSharer.saveCardPng(context, tinyBitmap())
         val second = NpcCardSharer.saveCardPng(context, tinyBitmap())
 
@@ -54,8 +43,7 @@ class NpcCardSharerTest {
         second.exists() shouldBe true
     }
 
-    @Test
-    fun `authority is derived from the running package name`() {
+    "authority is derived from the running package name" {
         NpcCardSharer.authority(context) shouldBe context.packageName + ".fileprovider"
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/share/NpcShareCardTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/share/NpcShareCardTest.kt
@@ -1,188 +1,188 @@
 package me.kerooker.rpgnpcgenerator.ui.share
 
 import android.app.Application
+import androidx.activity.ComponentActivity
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runAndroidComposeUiTest
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import me.kerooker.rpgnpcgenerator.data.Npc
-import org.junit.Rule
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-import org.robolectric.annotation.GraphicsMode
 
-@RunWith(RobolectricTestRunner::class)
-@GraphicsMode(GraphicsMode.Mode.NATIVE)
-@Config(sdk = [34], application = Application::class)
-class NpcShareCardTest {
-
-    @get:Rule
-    val composeRule = createComposeRule()
-
-    private val labels = NpcShareCardLabels(
-        profession = "Profession",
-        alignment = "Alignment",
-        motivation = "Motivation",
-        personality = "Personality",
-        languages = "Languages",
-        items = "Items",
-        combat = CombatSheetLabels(
-            title = "Combat stats",
-            strength = "STR",
-            dexterity = "DEX",
-            constitution = "CON",
-            intelligence = "INT",
-            wisdom = "WIS",
-            charisma = "CHA",
-            armorClass = "AC",
-            hitPoints = "HP",
-            challengeRating = "Challenge Rating"
-        )
+private val labels = NpcShareCardLabels(
+    profession = "Profession",
+    alignment = "Alignment",
+    motivation = "Motivation",
+    personality = "Personality",
+    languages = "Languages",
+    items = "Items",
+    combat = CombatSheetLabels(
+        title = "Combat stats",
+        strength = "STR",
+        dexterity = "DEX",
+        constitution = "CON",
+        intelligence = "INT",
+        wisdom = "WIS",
+        charisma = "CHA",
+        armorClass = "AC",
+        hitPoints = "HP",
+        challengeRating = "Challenge Rating"
     )
+)
 
-    private fun sampleNpc(
-        nickname: String = "The Swift",
-        personalityTraits: List<String> = listOf("Brave", "Curious"),
-        items: List<String> = emptyList()
-    ) = Npc(
-        id = 0,
-        fullName = "Aria Nightsong",
-        nickname = nickname,
-        gender = "Female",
-        sexuality = "Heterosexual",
-        race = "Human",
-        age = "Adult",
-        profession = "Blacksmith",
-        motivation = "Protect the forest",
-        alignment = "Neutral Good",
-        personalityTraits = personalityTraits,
-        languages = listOf("Common"),
-        imagePath = null,
-        notes = "",
-        strength = null,
-        dexterity = null,
-        constitution = null,
-        intelligence = null,
-        wisdom = null,
-        charisma = null,
-        armorClass = null,
-        hitPoints = null,
-        challengeRating = null,
-        campaign = null,
-        items = items
-    )
+private fun sampleNpc(
+    nickname: String = "The Swift",
+    personalityTraits: List<String> = listOf("Brave", "Curious"),
+    items: List<String> = emptyList()
+) = Npc(
+    id = 0,
+    fullName = "Aria Nightsong",
+    nickname = nickname,
+    gender = "Female",
+    sexuality = "Heterosexual",
+    race = "Human",
+    age = "Adult",
+    profession = "Blacksmith",
+    motivation = "Protect the forest",
+    alignment = "Neutral Good",
+    personalityTraits = personalityTraits,
+    languages = listOf("Common"),
+    imagePath = null,
+    notes = "",
+    strength = null,
+    dexterity = null,
+    constitution = null,
+    intelligence = null,
+    wisdom = null,
+    charisma = null,
+    armorClass = null,
+    hitPoints = null,
+    challengeRating = null,
+    campaign = null,
+    items = items
+)
 
-    @Test
-    fun `renders the npc key attributes and watermark`() {
-        composeRule.setContent {
-            MaterialTheme {
-                NpcShareCard(
-                    npc = sampleNpc(),
-                    portrait = null,
-                    footer = "Created with RPG NPC Generator",
-                    labels = labels
-                )
+@OptIn(ExperimentalTestApi::class)
+@RobolectricTest(sdk = [34], application = Application::class)
+class NpcShareCardTest : StringSpec({
+
+    "renders the npc key attributes and watermark" {
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    NpcShareCard(
+                        npc = sampleNpc(),
+                        portrait = null,
+                        footer = "Created with RPG NPC Generator",
+                        labels = labels
+                    )
+                }
             }
-        }
 
-        // The full card can be taller than the test viewport, so assert the attributes are composed
-        // into the card (exist in the semantics tree) rather than requiring them to be on-screen.
-        composeRule.onNodeWithText("Aria Nightsong").assertExists()
-        composeRule.onNodeWithText("The Swift", substring = true).assertExists()
-        composeRule.onNodeWithText("Human · Adult · Female").assertExists()
-        composeRule.onNodeWithText("Blacksmith").assertExists()
-        composeRule.onNodeWithText("Neutral Good").assertExists()
-        composeRule.onNodeWithText("Protect the forest").assertExists()
-        composeRule.onNodeWithText("Brave").assertExists()
-        composeRule.onNodeWithText("Curious").assertExists()
-        composeRule.onNodeWithText("Common").assertExists()
-        composeRule.onNodeWithText("Created with RPG NPC Generator").assertExists()
+            // The full card can be taller than the test viewport, so assert the attributes are composed
+            // into the card (exist in the semantics tree) rather than requiring them to be on-screen.
+            onNodeWithText("Aria Nightsong").assertExists()
+            onNodeWithText("The Swift", substring = true).assertExists()
+            onNodeWithText("Human · Adult · Female").assertExists()
+            onNodeWithText("Blacksmith").assertExists()
+            onNodeWithText("Neutral Good").assertExists()
+            onNodeWithText("Protect the forest").assertExists()
+            onNodeWithText("Brave").assertExists()
+            onNodeWithText("Curious").assertExists()
+            onNodeWithText("Common").assertExists()
+            onNodeWithText("Created with RPG NPC Generator").assertExists()
+        }
     }
 
-    @Test
-    fun `renders the combat stat block with ability modifiers when the npc has stats`() {
-        composeRule.setContent {
-            MaterialTheme {
-                NpcShareCard(
-                    npc = sampleNpc().copy(strength = 14, armorClass = 15, challengeRating = "1/4"),
-                    portrait = null,
-                    footer = "Created with RPG NPC Generator",
-                    labels = labels
-                )
+    "renders the combat stat block with ability modifiers when the npc has stats" {
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    NpcShareCard(
+                        npc = sampleNpc().copy(strength = 14, armorClass = 15, challengeRating = "1/4"),
+                        portrait = null,
+                        footer = "Created with RPG NPC Generator",
+                        labels = labels
+                    )
+                }
             }
-        }
 
-        composeRule.onNodeWithText("14 (+2)").assertExists()
-        composeRule.onNodeWithText("AC", substring = true).assertExists()
-        composeRule.onNodeWithText("1/4", substring = true).assertExists()
+            onNodeWithText("14 (+2)").assertExists()
+            onNodeWithText("AC", substring = true).assertExists()
+            onNodeWithText("1/4", substring = true).assertExists()
+        }
     }
 
-    @Test
-    fun `omits the combat stat block for a statless npc`() {
-        composeRule.setContent {
-            MaterialTheme {
-                NpcShareCard(
-                    npc = sampleNpc(),
-                    portrait = null,
-                    footer = "Created with RPG NPC Generator",
-                    labels = labels
-                )
+    "omits the combat stat block for a statless npc" {
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    NpcShareCard(
+                        npc = sampleNpc(),
+                        portrait = null,
+                        footer = "Created with RPG NPC Generator",
+                        labels = labels
+                    )
+                }
             }
-        }
 
-        // Section titles render uppercased, so the block's presence would show as "COMBAT STATS".
-        composeRule.onNodeWithText("COMBAT STATS").assertDoesNotExist()
+            // Section titles render uppercased, so the block's presence would show as "COMBAT STATS".
+            onNodeWithText("COMBAT STATS").assertDoesNotExist()
+        }
     }
 
-    @Test
-    fun `renders the items section as chips when the npc has items`() {
-        composeRule.setContent {
-            MaterialTheme {
-                NpcShareCard(
-                    npc = sampleNpc(items = listOf("A set of smith's tools", "A worn dagger")),
-                    portrait = null,
-                    footer = "Created with RPG NPC Generator",
-                    labels = labels
-                )
+    "renders the items section as chips when the npc has items" {
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    NpcShareCard(
+                        npc = sampleNpc(items = listOf("A set of smith's tools", "A worn dagger")),
+                        portrait = null,
+                        footer = "Created with RPG NPC Generator",
+                        labels = labels
+                    )
+                }
             }
-        }
 
-        composeRule.onNodeWithText("ITEMS").assertExists()
-        composeRule.onNodeWithText("A set of smith's tools").assertExists()
-        composeRule.onNodeWithText("A worn dagger").assertExists()
+            onNodeWithText("ITEMS").assertExists()
+            onNodeWithText("A set of smith's tools").assertExists()
+            onNodeWithText("A worn dagger").assertExists()
+        }
     }
 
-    @Test
-    fun `omits the items section when the npc has no items`() {
-        composeRule.setContent {
-            MaterialTheme {
-                NpcShareCard(
-                    npc = sampleNpc(items = emptyList()),
-                    portrait = null,
-                    footer = "Created with RPG NPC Generator",
-                    labels = labels
-                )
+    "omits the items section when the npc has no items" {
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    NpcShareCard(
+                        npc = sampleNpc(items = emptyList()),
+                        portrait = null,
+                        footer = "Created with RPG NPC Generator",
+                        labels = labels
+                    )
+                }
             }
-        }
 
-        composeRule.onNodeWithText("ITEMS").assertDoesNotExist()
+            onNodeWithText("ITEMS").assertDoesNotExist()
+        }
     }
 
-    @Test
-    fun `omits the nickname line when the npc has no nickname`() {
-        composeRule.setContent {
-            MaterialTheme {
-                NpcShareCard(
-                    npc = sampleNpc(nickname = ""),
-                    portrait = null,
-                    footer = "Created with RPG NPC Generator",
-                    labels = labels
-                )
+    "omits the nickname line when the npc has no nickname" {
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    NpcShareCard(
+                        npc = sampleNpc(nickname = ""),
+                        portrait = null,
+                        footer = "Created with RPG NPC Generator",
+                        labels = labels
+                    )
+                }
             }
-        }
 
-        composeRule.onNodeWithText("Aria Nightsong").assertExists()
-        composeRule.onNodeWithText("“", substring = true).assertDoesNotExist()
+            onNodeWithText("Aria Nightsong").assertExists()
+            onNodeWithText("“", substring = true).assertDoesNotExist()
+        }
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/theme/ThemePreferenceStoreTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/theme/ThemePreferenceStoreTest.kt
@@ -4,39 +4,32 @@ import android.app.Application
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.io.File
 import java.nio.file.Files
+
+private fun newStore(): ThemePreferenceStore {
+    val dir = Files.createTempDirectory("theme").toFile()
+    val dataStore: DataStore<Preferences> =
+        PreferenceDataStoreFactory.create { File(dir, "prefs.preferences_pb") }
+    return ThemePreferenceStore(dataStore)
+}
 
 /**
  * Exercises the real DataStore boundary of [ThemePreferenceStore] under Robolectric (mirrors
  * AdFreeStoreTest). Each store gets a fresh temp file so DataStore instances never clash.
  */
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
-class ThemePreferenceStoreTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class ThemePreferenceStoreTest : StringSpec({
 
-    private fun newStore(): ThemePreferenceStore {
-        val dir = Files.createTempDirectory("theme").toFile()
-        val dataStore: DataStore<Preferences> =
-            PreferenceDataStoreFactory.create { File(dir, "prefs.preferences_pb") }
-        return ThemePreferenceStore(dataStore)
-    }
-
-    @Test
-    fun `defaults to follow system when nothing is stored`() = runBlocking {
+    "defaults to follow system when nothing is stored" {
         newStore().themePreference.first() shouldBe ThemePreference.FOLLOW_SYSTEM
-        Unit
     }
 
-    @Test
-    fun `persists and reads back each preference`() = runBlocking {
+    "persists and reads back each preference" {
         val store = newStore()
 
         store.setThemePreference(ThemePreference.DARK)
@@ -47,6 +40,5 @@ class ThemePreferenceStoreTest {
 
         store.setThemePreference(ThemePreference.FOLLOW_SYSTEM)
         store.themePreference.first() shouldBe ThemePreference.FOLLOW_SYSTEM
-        Unit
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/util/ImageStoreTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/util/ImageStoreTest.kt
@@ -3,50 +3,40 @@ package me.kerooker.rpgnpcgenerator.ui.util
 import android.app.Application
 import android.graphics.Bitmap
 import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldStartWith
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-import org.robolectric.annotation.GraphicsMode
 import java.io.File
+
+private fun tinyBitmap(): Bitmap = Bitmap.createBitmap(4, 4, Bitmap.Config.ARGB_8888)
 
 /**
  * ImageStore touches `context.filesDir` and real `Bitmap`/`BitmapFactory` behaviour, neither of
  * which a plain JVM unit test can provide, so this runs on Robolectric with a real Context (as
- * NpcFieldTest does for Compose). GraphicsMode.NATIVE is needed so `Bitmap.compress` actually
- * encodes bytes instead of being an unshadowed no-op.
+ * NpcFieldTest does for Compose).
  */
-@RunWith(RobolectricTestRunner::class)
-@GraphicsMode(GraphicsMode.Mode.NATIVE)
-@Config(sdk = [34], application = Application::class)
-class ImageStoreTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class ImageStoreTest : StringSpec({
 
-    private lateinit var context: Application
-    private lateinit var portraitsDir: File
+    lateinit var context: Application
+    lateinit var portraitsDir: File
 
-    @Before
-    fun setUp() {
+    beforeTest {
         context = ApplicationProvider.getApplicationContext()
         portraitsDir = File(context.filesDir, "portraits")
     }
 
-    private fun tinyBitmap(): Bitmap = Bitmap.createBitmap(4, 4, Bitmap.Config.ARGB_8888)
-
-    @Test
-    fun `persistBitmap writes a jpeg file inside the portraits directory`() {
+    "persistBitmap writes a jpeg file inside the portraits directory" {
         val path = ImageStore.persistBitmap(context, tinyBitmap()).shouldNotBeNull()
 
         path shouldStartWith portraitsDir.absolutePath
         File(path).exists() shouldBe true
     }
 
-    @Test
-    fun `persistBitmap returns a distinct filename on every call`() {
+    "persistBitmap returns a distinct filename on every call" {
         val first = ImageStore.persistBitmap(context, tinyBitmap()).shouldNotBeNull()
         val second = ImageStore.persistBitmap(context, tinyBitmap()).shouldNotBeNull()
 
@@ -55,8 +45,7 @@ class ImageStoreTest {
         File(second).exists() shouldBe true
     }
 
-    @Test
-    fun `deletePortrait removes a file located inside the portraits directory`() {
+    "deletePortrait removes a file located inside the portraits directory" {
         portraitsDir.mkdirs()
         val file = File(portraitsDir, "existing.jpg").apply { writeText("fake-jpeg-bytes") }
 
@@ -65,8 +54,7 @@ class ImageStoreTest {
         file.exists() shouldBe false
     }
 
-    @Test
-    fun `deletePortrait ignores a file directly under filesDir`() {
+    "deletePortrait ignores a file directly under filesDir" {
         val file = File(context.filesDir, "not-a-portrait.jpg").apply { writeText("stray") }
 
         ImageStore.deletePortrait(context, file.absolutePath)
@@ -74,8 +62,7 @@ class ImageStoreTest {
         file.exists() shouldBe true
     }
 
-    @Test
-    fun `deletePortrait ignores a temp file elsewhere on disk`() {
+    "deletePortrait ignores a temp file elsewhere on disk" {
         val tempFile = File.createTempFile("portrait", ".jpg")
 
         try {
@@ -86,4 +73,4 @@ class ImageStoreTest {
             tempFile.delete()
         }
     }
-}
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/viewmodel/my/npc/RosterPreferencesTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/viewmodel/my/npc/RosterPreferencesTest.kt
@@ -4,39 +4,32 @@ import android.app.Application
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.io.File
 import java.nio.file.Files
+
+private fun newPreferences(): RosterPreferences {
+    val dir = Files.createTempDirectory("roster").toFile()
+    val dataStore: DataStore<Preferences> =
+        PreferenceDataStoreFactory.create { File(dir, "prefs.preferences_pb") }
+    return RosterPreferences(dataStore)
+}
 
 /**
  * Exercises the real DataStore boundary of [RosterPreferences] under Robolectric. Each store gets a
  * fresh temp file so DataStore instances never clash.
  */
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
-class RosterPreferencesTest {
+@RobolectricTest(sdk = [34], application = Application::class)
+class RosterPreferencesTest : StringSpec({
 
-    private fun newPreferences(): RosterPreferences {
-        val dir = Files.createTempDirectory("roster").toFile()
-        val dataStore: DataStore<Preferences> =
-            PreferenceDataStoreFactory.create { File(dir, "prefs.preferences_pb") }
-        return RosterPreferences(dataStore)
-    }
-
-    @Test
-    fun `defaults to name ascending`() = runBlocking {
+    "defaults to name ascending" {
         newPreferences().sortOrder.first() shouldBe NpcSortOrder.NAME_ASC
-        Unit
     }
 
-    @Test
-    fun `persists and reads back the chosen sort order`() = runBlocking {
+    "persists and reads back the chosen sort order" {
         val preferences = newPreferences()
 
         preferences.setSortOrder(NpcSortOrder.RECENTLY_ADDED)
@@ -44,6 +37,5 @@ class RosterPreferencesTest {
 
         preferences.setSortOrder(NpcSortOrder.NAME_DESC)
         preferences.sortOrder.first() shouldBe NpcSortOrder.NAME_DESC
-        Unit
     }
-}
+})

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,8 +13,9 @@ kotlinxCoroutines = "1.10.1"
 coil = "3.2.0"
 aboutlibraries = "12.2.4"
 detekt = "1.23.8"
-kotest = "5.9.1"
-robolectric = "4.15.1"
+kotest = "6.2.2"
+kotestAndroid = "0.1.12"
+robolectric = "4.16.1"
 mockk = "1.14.2"
 turbine = "1.2.1"
 splashscreen = "1.2.0-rc01"
@@ -91,7 +92,7 @@ turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTest" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
-junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version = "5.11.4" }
+kotest-extensions-android = { module = "br.com.colman:kotest-extensions-android", version.ref = "kotestAndroid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- All 15 Robolectric test classes (`@RunWith(RobolectricTestRunner::class)`) now run as Kotest `StringSpec`s via `br.com.colman:kotest-extensions-android:0.1.12`'s `@RobolectricTest` annotation — `junit-vintage-engine` is no longer needed and has been removed.
- Bumps `kotest` 5.9.1 → 6.2.2 and `robolectric` 4.15.1 → 4.16.1, required because the library's `@RobolectricTest` is built on Kotest 6's `@ApplyExtension` mechanism.
- The two Compose UI test classes (`NpcFieldTest`, `NpcShareCardTest`) swap `createComposeRule()` + `@get:Rule` (no JUnit4 rule processing happens outside a JUnit4 runner) for `runAndroidComposeUiTest<ComponentActivity> { ... }`, a rule-free top-level function already on the `ui-test-junit4` classpath.
- Drops the now-inert `@GraphicsMode(GraphicsMode.Mode.NATIVE)` from `ImageStoreTest`/`NpcCardSharerTest` — verified empirically that Robolectric 4.16.1 encodes real JPEG/PNG bytes by default regardless of the annotation.

## Test plan
- [x] `:app:testDebugUnitTest` — 224 tests, 0 failures/errors
- [x] `:portrait-queue:test` — 23 tests, 0 failures/errors (shares the bumped Kotest catalog entry)
- [x] `:app:detekt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)