### PR TITLE
test: add Kotest Compose UI tests for TagsSection, EditableListSection, CombatStatsSection

### DIFF
--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/components/CombatStatsSectionTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/components/CombatStatsSectionTest.kt
@@ -1,0 +1,96 @@
+package me.kerooker.rpgnpcgenerator.ui.components
+
+import android.app.Application
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.runAndroidComposeUiTest
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(ExperimentalTestApi::class)
+@RobolectricTest(sdk = [34], application = Application::class)
+class CombatStatsSectionTest : StringSpec({
+
+    "the reroll-all die calls onReroll" {
+        var rerolled = false
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    CombatStatsSection(
+                        stats = CombatStatsUi(),
+                        editable = true,
+                        onReroll = { rerolled = true }
+                    )
+                }
+            }
+
+            onNodeWithContentDescription("Regenerate all Combat stats").performClick()
+        }
+
+        rerolled shouldBe true
+    }
+
+    "the lock toggle calls onToggleLock" {
+        var toggled = false
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    CombatStatsSection(
+                        stats = CombatStatsUi(),
+                        editable = true,
+                        locked = false,
+                        onToggleLock = { toggled = true }
+                    )
+                }
+            }
+
+            onNodeWithContentDescription("Lock Combat stats so it survives Randomize all").performClick()
+        }
+
+        toggled shouldBe true
+    }
+
+    "editing the strength field propagates the updated stats" {
+        var changed: CombatStatsUi? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    CombatStatsSection(
+                        stats = CombatStatsUi(),
+                        editable = true,
+                        onStatsChange = { changed = it }
+                    )
+                }
+            }
+
+            onNodeWithText("STR").performTextReplacement("14")
+        }
+
+        changed shouldBe CombatStatsUi(strength = "14")
+    }
+
+    "editing the challenge rating field propagates the updated stats" {
+        var changed: CombatStatsUi? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    CombatStatsSection(
+                        stats = CombatStatsUi(),
+                        editable = true,
+                        onStatsChange = { changed = it }
+                    )
+                }
+            }
+
+            onNodeWithText("Challenge Rating").performTextReplacement("5")
+        }
+
+        changed shouldBe CombatStatsUi(challengeRating = "5")
+    }
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/components/EditableListSectionTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/components/EditableListSectionTest.kt
@@ -1,0 +1,161 @@
+package me.kerooker.rpgnpcgenerator.ui.components
+
+import android.app.Application
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.runAndroidComposeUiTest
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(ExperimentalTestApi::class)
+@RobolectricTest(sdk = [34], application = Application::class)
+class EditableListSectionTest : StringSpec({
+
+    "editing an item's text propagates through onItemChange" {
+        var edited: Pair<Int, String>? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    EditableListSection(
+                        title = "Languages",
+                        itemLabel = "Language",
+                        items = listOf("Common"),
+                        editable = true,
+                        onItemChange = { index, value -> edited = index to value },
+                        onRemove = {},
+                        onAdd = {}
+                    )
+                }
+            }
+
+            onNodeWithText("Common").performTextReplacement("Elvish")
+        }
+
+        edited shouldBe (0 to "Elvish")
+    }
+
+    "removing an item calls onRemove with its index" {
+        var removedIndex: Int? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    EditableListSection(
+                        title = "Languages",
+                        itemLabel = "Language",
+                        items = listOf("Common"),
+                        editable = true,
+                        onItemChange = { _, _ -> },
+                        onRemove = { removedIndex = it },
+                        onAdd = {}
+                    )
+                }
+            }
+
+            onNodeWithContentDescription("Remove Language").performClick()
+        }
+
+        removedIndex shouldBe 0
+    }
+
+    "rerolling one item calls onReroll with its index" {
+        var rerolledIndex: Int? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    EditableListSection(
+                        title = "Languages",
+                        itemLabel = "Language",
+                        items = listOf("Common"),
+                        editable = true,
+                        onItemChange = { _, _ -> },
+                        onRemove = {},
+                        onAdd = {},
+                        onReroll = { rerolledIndex = it }
+                    )
+                }
+            }
+
+            onNodeWithContentDescription("Re-roll Language").performClick()
+        }
+
+        rerolledIndex shouldBe 0
+    }
+
+    "the reroll-all die calls onRerollAll" {
+        var rerolledAll = false
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    EditableListSection(
+                        title = "Languages",
+                        itemLabel = "Language",
+                        items = listOf("Common"),
+                        editable = true,
+                        onItemChange = { _, _ -> },
+                        onRemove = {},
+                        onAdd = {},
+                        onRerollAll = { rerolledAll = true }
+                    )
+                }
+            }
+
+            onNodeWithContentDescription("Regenerate all Languages").performClick()
+        }
+
+        rerolledAll shouldBe true
+    }
+
+    "tapping Add Item calls onAdd" {
+        var added = false
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    EditableListSection(
+                        title = "Languages",
+                        itemLabel = "Language",
+                        items = emptyList(),
+                        editable = true,
+                        onItemChange = { _, _ -> },
+                        onRemove = {},
+                        onAdd = { added = true }
+                    )
+                }
+            }
+
+            onNodeWithText("Add Item").performClick()
+        }
+
+        added shouldBe true
+    }
+
+    "the lock toggle calls onToggleLock" {
+        var toggled = false
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    EditableListSection(
+                        title = "Languages",
+                        itemLabel = "Language",
+                        items = emptyList(),
+                        editable = true,
+                        onItemChange = { _, _ -> },
+                        onRemove = {},
+                        onAdd = {},
+                        locked = false,
+                        onToggleLock = { toggled = true }
+                    )
+                }
+            }
+
+            onNodeWithContentDescription("Lock Languages so it survives Randomize all").performClick()
+        }
+
+        toggled shouldBe true
+    }
+})

--- a/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/components/TagsSectionTest.kt
+++ b/app/src/test/java/me/kerooker/rpgnpcgenerator/ui/components/TagsSectionTest.kt
@@ -1,0 +1,181 @@
+package me.kerooker.rpgnpcgenerator.ui.components
+
+import android.app.Application
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runAndroidComposeUiTest
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(ExperimentalTestApi::class)
+@RobolectricTest(sdk = [34], application = Application::class)
+class TagsSectionTest : StringSpec({
+
+    "tapping the add-tag icon after typing appends the trimmed tag" {
+        var result: List<String>? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = emptyList(),
+                        editable = true,
+                        suggestions = emptyList(),
+                        onTagsChange = { result = it }
+                    )
+                }
+            }
+
+            onNodeWithText("Add a tag").performTextInput("Veteran")
+            onNodeWithContentDescription("Add tag").performClick()
+        }
+
+        result shouldBe listOf("Veteran")
+    }
+
+    "pressing IME done after typing appends the tag" {
+        var result: List<String>? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = emptyList(),
+                        editable = true,
+                        suggestions = emptyList(),
+                        onTagsChange = { result = it }
+                    )
+                }
+            }
+
+            onNodeWithText("Add a tag").performTextInput("Undead")
+            onNodeWithText("Undead").performImeAction()
+        }
+
+        result shouldBe listOf("Undead")
+    }
+
+    "tapping a tag's remove icon removes it" {
+        var result: List<String>? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = listOf("Old"),
+                        editable = true,
+                        suggestions = emptyList(),
+                        onTagsChange = { result = it }
+                    )
+                }
+            }
+
+            onNodeWithContentDescription("Remove Old").performClick()
+        }
+
+        result shouldBe emptyList()
+    }
+
+    "tapping a suggestion chip adds it" {
+        var result: List<String>? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = emptyList(),
+                        editable = true,
+                        suggestions = listOf("Merchant"),
+                        onTagsChange = { result = it }
+                    )
+                }
+            }
+
+            onNodeWithText("Merchant").performClick()
+        }
+
+        result shouldBe listOf("Merchant")
+    }
+
+    "a duplicate tag (case-insensitive) is not added again" {
+        var called = false
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = listOf("Veteran"),
+                        editable = true,
+                        suggestions = emptyList(),
+                        onTagsChange = { called = true }
+                    )
+                }
+            }
+
+            onNodeWithText("Add a tag").performTextInput("veteran")
+            onNodeWithContentDescription("Add tag").performClick()
+        }
+
+        called shouldBe false
+    }
+
+    "blank input is ignored" {
+        var called = false
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = emptyList(),
+                        editable = true,
+                        suggestions = emptyList(),
+                        onTagsChange = { called = true }
+                    )
+                }
+            }
+
+            onNodeWithText("Add a tag").performTextInput("   ")
+            onNodeWithContentDescription("Add tag").performClick()
+        }
+
+        called shouldBe false
+    }
+
+    "non-editable mode renders plain chips with no input or remove affordance" {
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = listOf("Merchant"),
+                        editable = false,
+                        suggestions = emptyList(),
+                        onTagsChange = {}
+                    )
+                }
+            }
+
+            onNodeWithText("Merchant").assertIsDisplayed()
+            onNodeWithText("Add a tag").assertDoesNotExist()
+            onNodeWithContentDescription("Remove Merchant").assertDoesNotExist()
+        }
+    }
+
+    "non-editable mode with no tags renders nothing" {
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = emptyList(),
+                        editable = false,
+                        suggestions = emptyList(),
+                        onTagsChange = {}
+                    )
+                }
+            }
+
+            onNodeWithText("Tags").assertDoesNotExist()
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- Extends the Robolectric-based Compose UI testing pattern already established by `NpcFieldTest.kt` (`@RobolectricTest` + Kotest `StringSpec` + `runAndroidComposeUiTest`) to the other interactive, DI-free composables in `ui/components` that had no coverage yet.
- `TagsSectionTest.kt`: add via icon/IME, remove via chip, tap-to-add suggestion, case-insensitive duplicate rejected, blank ignored, non-editable rendering (with and without tags).
- `EditableListSectionTest.kt`: edit item text, remove by index, reroll one/all, add item, lock toggle.
- `CombatStatsSectionTest.kt`: reroll-all, lock toggle, field edits propagate via `CombatStatsUi.copy`.

## Test plan
- [x] `./gradlew testDebugUnitTest --tests "me.kerooker.rpgnpcgenerator.ui.components.*"` — all 18 new cases green
- [x] `./gradlew detekt` clean
- [x] Full `./gradlew testDebugUnitTest` run (whole suite) green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)