### PR TITLE
test: add real on-device instrumentation testing + CI

### DIFF
--- a/.github/workflows/instrumented-tests.main.kts
+++ b/.github/workflows/instrumented-tests.main.kts
@@ -1,0 +1,64 @@
+#!/usr/bin/env kotlin
+@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://central.sonatype.com/repository/maven-snapshots/")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:4.0.0")
+
+@file:Repository("https://bindings.krzeminski.it")
+@file:DependsOn("actions:checkout:v4")
+@file:DependsOn("actions:setup-java:v4")
+@file:DependsOn("actions:upload-artifact:v4")
+@file:DependsOn("gradle:actions__setup-gradle:v4")
+@file:DependsOn("reactivecircus:android-emulator-runner:v2")
+
+import io.github.typesafegithub.workflows.actions.actions.Checkout
+import io.github.typesafegithub.workflows.actions.actions.SetupJava
+import io.github.typesafegithub.workflows.actions.actions.UploadArtifact
+import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
+import io.github.typesafegithub.workflows.actions.reactivecircus.AndroidEmulatorRunner
+import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
+import io.github.typesafegithub.workflows.domain.triggers.PullRequest
+import io.github.typesafegithub.workflows.domain.triggers.Push
+import io.github.typesafegithub.workflows.dsl.workflow
+
+workflow(
+  name = "Instrumented Tests",
+  on = listOf(Push(), PullRequest()),
+  sourceFile = __FILE__
+) {
+  job(id = "instrumented-test", runsOn = UbuntuLatest) {
+    uses(name = "Checkout", action = Checkout())
+    uses(
+      name = "Set up JDK 21",
+      action = SetupJava(javaVersion = "21", distribution = SetupJava.Distribution.Temurin)
+    )
+    uses(name = "Set up Gradle", action = ActionsSetupGradle())
+
+    run(
+      name = "Enable KVM group perms",
+      command = """
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+      """.trimIndent()
+    )
+
+    uses(
+      name = "Run instrumented tests",
+      action = AndroidEmulatorRunner(
+        apiLevel = "34",
+        target = AndroidEmulatorRunner.Target.GoogleApis,
+        arch = AndroidEmulatorRunner.Arch.X8664,
+        script = "./gradlew connectedDebugAndroidTest"
+      )
+    )
+
+    uses(
+      name = "Upload reports on failure",
+      `if` = "failure()",
+      action = UploadArtifact(
+        name = "instrumented-test-reports",
+        path = listOf("app/build/reports/androidTests", "app/build/outputs/androidTest-results")
+      )
+    )
+  }
+}

--- a/.github/workflows/instrumented-tests.yaml
+++ b/.github/workflows/instrumented-tests.yaml
@@ -1,0 +1,62 @@
+# This file was generated using Kotlin DSL (.github/workflows/instrumented-tests.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/typesafegithub/github-workflows-kt
+
+name: 'Instrumented Tests'
+on:
+  push: {}
+  pull_request: {}
+jobs:
+  check_yaml_consistency:
+    name: 'Check YAML consistency'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - id: 'step-0'
+      name: 'Check out'
+      uses: 'actions/checkout@v4'
+    - id: 'step-1'
+      name: 'Execute script'
+      run: 'rm ''.github/workflows/instrumented-tests.yaml'' && ''.github/workflows/instrumented-tests.main.kts'''
+    - id: 'step-2'
+      name: 'Consistency check'
+      run: 'git diff --exit-code ''.github/workflows/instrumented-tests.yaml'''
+  instrumented-test:
+    runs-on: 'ubuntu-latest'
+    needs:
+    - 'check_yaml_consistency'
+    steps:
+    - id: 'step-0'
+      name: 'Checkout'
+      uses: 'actions/checkout@v4'
+    - id: 'step-1'
+      name: 'Set up JDK 21'
+      uses: 'actions/setup-java@v4'
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+    - id: 'step-2'
+      name: 'Set up Gradle'
+      uses: 'gradle/actions/setup-gradle@v4'
+    - id: 'step-3'
+      name: 'Enable KVM group perms'
+      run: |-
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+    - id: 'step-4'
+      name: 'Run instrumented tests'
+      uses: 'reactivecircus/android-emulator-runner@v2'
+      with:
+        api-level: '34'
+        target: 'google_apis'
+        arch: 'x86_64'
+        script: './gradlew connectedDebugAndroidTest'
+    - id: 'step-5'
+      name: 'Upload reports on failure'
+      uses: 'actions/upload-artifact@v4'
+      with:
+        name: 'instrumented-test-reports'
+        path: |-
+          app/build/reports/androidTests
+          app/build/outputs/androidTest-results
+      if: 'failure()'

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -266,4 +266,12 @@ dependencies {
     // https://github.com/LeoColman/kotest-android
     testImplementation(libs.kotest.extensions.android)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+
+    // Compose UI tests on a real device/emulator (androidTest), mirroring the Robolectric ones above
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.kotest.assertions.core)
+    // Kotest spec support for real instrumentation, see https://github.com/LeoColman/kotest-android
+    androidTestImplementation(libs.kotest.runner.android)
 }

--- a/app/src/androidTest/java/me/kerooker/rpgnpcgenerator/ui/components/NpcFieldTest.kt
+++ b/app/src/androidTest/java/me/kerooker/rpgnpcgenerator/ui/components/NpcFieldTest.kt
@@ -10,9 +10,12 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.runAndroidComposeUiTest
 import br.com.colman.kotest.FunSpec
+import br.com.colman.kotest.KotestRunnerAndroid
 import io.kotest.matchers.shouldBe
+import org.junit.runner.RunWith
 
 @OptIn(ExperimentalTestApi::class)
+@RunWith(KotestRunnerAndroid::class)
 class NpcFieldTest : FunSpec({
 
     test("displays the value and reroll invokes the callback") {

--- a/app/src/androidTest/java/me/kerooker/rpgnpcgenerator/ui/components/NpcFieldTest.kt
+++ b/app/src/androidTest/java/me/kerooker/rpgnpcgenerator/ui/components/NpcFieldTest.kt
@@ -1,0 +1,59 @@
+package me.kerooker.rpgnpcgenerator.ui.components
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.runAndroidComposeUiTest
+import br.com.colman.kotest.FunSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(ExperimentalTestApi::class)
+class NpcFieldTest : FunSpec({
+
+    test("displays the value and reroll invokes the callback") {
+        var rerolled = false
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    NpcField(
+                        label = "Race",
+                        value = "Human",
+                        editable = true,
+                        onValueChange = {},
+                        onReroll = { rerolled = true }
+                    )
+                }
+            }
+
+            onNodeWithText("Human").assertIsDisplayed()
+            onNodeWithContentDescription("Re-roll Race").performClick()
+        }
+
+        rerolled shouldBe true
+    }
+
+    test("editing the value propagates through onValueChange") {
+        var current = "Human"
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    NpcField(
+                        label = "Race",
+                        value = current,
+                        editable = true,
+                        onValueChange = { current = it }
+                    )
+                }
+            }
+
+            onNodeWithText("Human").performTextReplacement("Elf")
+        }
+
+        current shouldBe "Elf"
+    }
+})

--- a/app/src/androidTest/java/me/kerooker/rpgnpcgenerator/ui/components/TagsSectionTest.kt
+++ b/app/src/androidTest/java/me/kerooker/rpgnpcgenerator/ui/components/TagsSectionTest.kt
@@ -11,9 +11,12 @@ import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.runAndroidComposeUiTest
 import br.com.colman.kotest.FunSpec
+import br.com.colman.kotest.KotestRunnerAndroid
 import io.kotest.matchers.shouldBe
+import org.junit.runner.RunWith
 
 @OptIn(ExperimentalTestApi::class)
+@RunWith(KotestRunnerAndroid::class)
 class TagsSectionTest : FunSpec({
 
     test("tapping the add-tag icon after typing appends the trimmed tag") {

--- a/app/src/androidTest/java/me/kerooker/rpgnpcgenerator/ui/components/TagsSectionTest.kt
+++ b/app/src/androidTest/java/me/kerooker/rpgnpcgenerator/ui/components/TagsSectionTest.kt
@@ -1,0 +1,178 @@
+package me.kerooker.rpgnpcgenerator.ui.components
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runAndroidComposeUiTest
+import br.com.colman.kotest.FunSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(ExperimentalTestApi::class)
+class TagsSectionTest : FunSpec({
+
+    test("tapping the add-tag icon after typing appends the trimmed tag") {
+        var result: List<String>? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = emptyList(),
+                        editable = true,
+                        suggestions = emptyList(),
+                        onTagsChange = { result = it }
+                    )
+                }
+            }
+
+            onNodeWithText("Add a tag").performTextInput("Veteran")
+            onNodeWithContentDescription("Add tag").performClick()
+        }
+
+        result shouldBe listOf("Veteran")
+    }
+
+    test("pressing IME done after typing appends the tag") {
+        var result: List<String>? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = emptyList(),
+                        editable = true,
+                        suggestions = emptyList(),
+                        onTagsChange = { result = it }
+                    )
+                }
+            }
+
+            onNodeWithText("Add a tag").performTextInput("Undead")
+            onNodeWithText("Undead").performImeAction()
+        }
+
+        result shouldBe listOf("Undead")
+    }
+
+    test("tapping a tag's remove icon removes it") {
+        var result: List<String>? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = listOf("Old"),
+                        editable = true,
+                        suggestions = emptyList(),
+                        onTagsChange = { result = it }
+                    )
+                }
+            }
+
+            onNodeWithContentDescription("Remove Old").performClick()
+        }
+
+        result shouldBe emptyList()
+    }
+
+    test("tapping a suggestion chip adds it") {
+        var result: List<String>? = null
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = emptyList(),
+                        editable = true,
+                        suggestions = listOf("Merchant"),
+                        onTagsChange = { result = it }
+                    )
+                }
+            }
+
+            onNodeWithText("Merchant").performClick()
+        }
+
+        result shouldBe listOf("Merchant")
+    }
+
+    test("a duplicate tag (case-insensitive) is not added again") {
+        var called = false
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = listOf("Veteran"),
+                        editable = true,
+                        suggestions = emptyList(),
+                        onTagsChange = { called = true }
+                    )
+                }
+            }
+
+            onNodeWithText("Add a tag").performTextInput("veteran")
+            onNodeWithContentDescription("Add tag").performClick()
+        }
+
+        called shouldBe false
+    }
+
+    test("blank input is ignored") {
+        var called = false
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = emptyList(),
+                        editable = true,
+                        suggestions = emptyList(),
+                        onTagsChange = { called = true }
+                    )
+                }
+            }
+
+            onNodeWithText("Add a tag").performTextInput("   ")
+            onNodeWithContentDescription("Add tag").performClick()
+        }
+
+        called shouldBe false
+    }
+
+    test("non-editable mode renders plain chips with no input or remove affordance") {
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = listOf("Merchant"),
+                        editable = false,
+                        suggestions = emptyList(),
+                        onTagsChange = {}
+                    )
+                }
+            }
+
+            onNodeWithText("Merchant").assertIsDisplayed()
+            onNodeWithText("Add a tag").assertDoesNotExist()
+            onNodeWithContentDescription("Remove Merchant").assertDoesNotExist()
+        }
+    }
+
+    test("non-editable mode with no tags renders nothing") {
+        runAndroidComposeUiTest<ComponentActivity> {
+            setContent {
+                MaterialTheme {
+                    TagsSection(
+                        tags = emptyList(),
+                        editable = false,
+                        suggestions = emptyList(),
+                        onTagsChange = {}
+                    )
+                }
+            }
+
+            onNodeWithText("Tags").assertDoesNotExist()
+        }
+    }
+})

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,7 +93,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTest" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 kotest-extensions-android = { module = "br.com.colman:kotest-extensions-android", version.ref = "kotestAndroid" }
-kotest-runner-android = { module = "br.com.colman:kotest-runner-android", version = "1.2.2" }
+kotest-runner-android = { module = "br.com.colman:kotest-runner-android", version = "1.2.3" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,6 +93,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTest" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 kotest-extensions-android = { module = "br.com.colman:kotest-extensions-android", version.ref = "kotestAndroid" }
+kotest-runner-android = { module = "br.com.colman:kotest-runner-android", version = "1.2.2" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Wires up `br.com.colman:kotest-runner-android:1.2.2` so Kotest specs can run as genuine `androidTest` instrumentation (real device/emulator), matching how Petals does it — separate from and additive to this repo's existing Robolectric-based Compose UI tests.
- Ports `NpcFieldTest` and `TagsSectionTest` to real instrumentation (`app/src/androidTest`) to prove the pipeline actually works, using a bare `ComponentActivity` rather than the real `MainActivity` (which does live Koin/AdMob-consent init on `onCreate` — driving that on a fresh CI emulator would be a flakiness risk and is out of scope here).
- Adds `.github/workflows/instrumented-tests.main.kts` (Kotlin DSL, matching this repo's other workflows) running the new suite via `reactivecircus/android-emulator-runner` (API 34, google_apis, x86_64) on `push`/`pull_request`.

## Test plan
- [x] `./gradlew compileDebugAndroidTestKotlin` succeeds
- [x] `./gradlew detekt` clean
- [x] Workflow yaml regenerates byte-identical from its `.main.kts` (consistency check)
- [ ] **Unverified**: actual `connectedDebugAndroidTest` execution on an emulator — no KVM/emulator available in the sandbox this was built in. First real signal comes from this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)